### PR TITLE
Add note that login screen is optional

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -66,6 +66,7 @@
       <img src="banno-logo.png" height="20px" alt="Banno"/>
       <span>Sign in with Banno</span>
     </a>
+    (This example login screen is optional. You can redirect users to Banno for authentication instead.)
   </section>
 
   <script type="text/javascript">

--- a/public/login.html
+++ b/public/login.html
@@ -66,7 +66,8 @@
       <img src="banno-logo.png" height="20px" alt="Banno"/>
       <span>Sign in with Banno</span>
     </a>
-    (This example login screen is optional. You can redirect users to Banno for authentication instead.)
+    This example login screen is optional. You can redirect users to Banno for authentication instead.
+    <br/><br/>However, if you auto-redirect then you'll need to have a mechanism in place to prevent Cross-Site Request Forgery (CSRF) attacks.
   </section>
 
   <script type="text/javascript">


### PR DESCRIPTION
The example shows a dedicated login screen (`login.html`). This is an optional step for customers, who can redirect users to Banno for authentication instead.

The updated login screen now looks like this:
<img width="416" alt="Screen Shot 2019-11-22 at 4 26 47 PM" src="https://user-images.githubusercontent.com/31429468/69469434-b04d9380-0d45-11ea-98d0-83a9f76f3710.png">

_Edit: Updated screenshot in this PR to match latest commit https://github.com/Banno/consumer-api-openid-connect-example/pull/2/commits/c39eb92c351ce78d2d5b8f2367fc4dad0970d87a_
