### PR TITLE
Add accounts and transactions route

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,19 @@ If a user visits https://localhost:8080/hello but _is not yet authenticated_, th
 A `state` is calculated and associated with the `returnPath` (in this case, `/hello`).
 
 Once the user is authenticated, the `state` parameter is compared to the local `state` and if it matches then the user is redirected to the associated `returnPath` (in this case, `/hello`).
+
+# Retrieving Accounts and Transactions
+
+An example of how to retrieve Accounts and Transactions for a user is shown in the `'/accountsAndTransactions'` route within `server.js`.
+
+If a user visits https://localhost:8080/accountsAndTransactions and authenticates, the server will retrieve the Accounts and Transactions for the user and 'pretty print' the data to the page.
+
+## Retrieval Process
+
+1. The server makes an API call to `PUT /a/consumer/api/users/{userId}/fetch`. The response contains an object with a `taskId` property.
+
+2. The server then makes API calls to `GET /a/consumer/api/users/{userId}/tasks/{taskId}` and polls until an event type of `TaskEnded` is found. _(The amount of time this takes is variable based on the number of accounts a user has as well as the hardware the Financial Institution uses for its Core System.)_
+
+3. After polling is completed, the server makes API calls to `GET /a/consumer/api/users/{userId}/accounts` and `GET /a/consumer/api/users/{userId}/transactions`.
+
+4. Finally, the collected data is 'pretty printed' to the page returned to the user.

--- a/config.js
+++ b/config.js
@@ -16,5 +16,9 @@ module.exports = {
       token_endpoint_auth_method: 'client_secret_basic',
       redirect_uris: ['https://localhost:8080/auth/cb']
     }
+  },
+  consumerApi: {
+    environment: 'https://silverlake.banno-production.com',
+    usersBase: '/a/consumer/api/users/'
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,6 +483,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-forge": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "express": "^4.16.4",
     "express-session": "^1.15.6",
     "openid-client": "^2.4.5",
-    "passport": "^0.4.0"
+    "passport": "^0.4.0",
+    "node-fetch": "2.6.0"
   },
   "engines": {
     "node": ">=6"

--- a/server.js
+++ b/server.js
@@ -154,28 +154,16 @@ async function getAccountsAndTransactions(userId) {
   const bearerToken = ''
   const consumerApiEnvironment = 'https://silverlake.banno-production.com'
   const consumerApiUsersBase = '/a/consumer/api/users/'
+  const consumerApiPath = consumerApiEnvironment + consumerApiUsersBase;
   
   // PUT Fetch
-  const fetchApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/fetch', {
-    method: 'put',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
-  });
-  
-  const fetchApiJson = await fetchApiResponse.json();
-  const taskId = fetchApiJson.taskId;
+  const taskId = await putFetch(consumerApiPath, userId, bearerToken);
 
   console.log('Task ID: ' + taskId);
   sleep(2000);
 
   // GET Tasks
-  const tasksApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/tasks/' + taskId, {
-    method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
-  });
-
-  const tasksApiJson = await tasksApiResponse.json();
-
-  const events = tasksApiJson.events;
+  const events = await getTasks(consumerApiPath, userId, taskId, bearerToken);
 
   events.forEach(event => {
     const eventType = event.type;
@@ -184,14 +172,7 @@ async function getAccountsAndTransactions(userId) {
   });
 
   // GET Accounts
-  const accountsApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/accounts', {
-    method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
-  });
-
-  const accountsApiJson = await accountsApiResponse.json();
-
-  const accounts = accountsApiJson.accounts;
+  const accounts = await getAccounts(consumerApiPath, userId, bearerToken);
 
   accounts.forEach(account => {
     const accountId = account.id;
@@ -201,14 +182,7 @@ async function getAccountsAndTransactions(userId) {
   });
 
   // GET Transactions
-  const transactionsApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/transactions', {
-    method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
-  });
-
-  const transactionsApiJson = await transactionsApiResponse.json();
-
-  const transactions = transactionsApiJson.transactions;
+  const transactions = await getTransactions(consumerApiPath, userId, bearerToken);
 
   transactions.forEach(transaction => {
     const transactionId = transaction.id;
@@ -217,6 +191,46 @@ async function getAccountsAndTransactions(userId) {
 
     console.log('Transaction -> ID: ' + transactionId + ' , Amount: ' + transactionAmount + ' , Memo: ' + transactionMemo);
   });
+}
+
+async function getTransactions(consumerApiPath, userId, bearerToken) {
+  const transactionsApiResponse = await fetch(consumerApiPath + userId + '/transactions', {
+    method: 'get',
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
+  });
+  const transactionsApiJson = await transactionsApiResponse.json();
+  const transactions = transactionsApiJson.transactions;
+  return transactions;
+}
+
+async function getAccounts(consumerApiPath, userId, bearerToken) {
+  const accountsApiResponse = await fetch(consumerApiPath + userId + '/accounts', {
+    method: 'get',
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
+  });
+  const accountsApiJson = await accountsApiResponse.json();
+  const accounts = accountsApiJson.accounts;
+  return accounts;
+}
+
+async function getTasks(consumerApiPath, userId, taskId, bearerToken) {
+  const tasksApiResponse = await fetch(consumerApiPath + userId + '/tasks/' + taskId, {
+    method: 'get',
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
+  });
+  const tasksApiJson = await tasksApiResponse.json();
+  const events = tasksApiJson.events;
+  return events;
+}
+
+async function putFetch(consumerApiPath, userId, bearerToken) {
+  const fetchApiResponse = await fetch(consumerApiPath + userId + '/fetch', {
+    method: 'put',
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
+  });
+  const fetchApiJson = await fetchApiResponse.json();
+  const taskId = fetchApiJson.taskId;
+  return taskId;
 }
 
 function sleep(milliseconds) {

--- a/server.js
+++ b/server.js
@@ -147,8 +147,6 @@ app.get('/accountsAndTransactions', (req, res) => {
     return;
   }
 
-  console.log('<=========================================================================================>');
-
   const userId = req.session.passport.user.sub;
 
   getAccountsAndTransactions(userId, res);
@@ -166,8 +164,6 @@ async function getAccountsAndTransactions(userId, res) {
   // PUT Fetch
   const taskId = await putFetch(consumerApiPath, userId, accessToken);
 
-  console.log('Task ID: ' + taskId);
-
   // GET Tasks
   await getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, taskId, accessToken);
 
@@ -177,8 +173,6 @@ async function getAccountsAndTransactions(userId, res) {
   accounts.forEach(account => {
     const accountId = account.id;
     const accountBalance = account.balance;
-
-    console.log('Account -> ID: ' + accountId + ' , Balance: ' + accountBalance);
 
     output += 'Account ID: ' + accountId + '\n';
     output += '  ' + 'Balance: ' + accountBalance + '\n\n';
@@ -192,8 +186,6 @@ async function getAccountsAndTransactions(userId, res) {
     const transactionAccountId = transaction.accountId;
     const transactionAmount = transaction.amount;
     const transactionMemo = transaction.memo;
-
-    console.log('Transaction -> ID: ' + transactionId + ' , Amount: ' + transactionAmount + ' , Memo: ' + transactionMemo);
 
     output += 'Transaction ID: ' + transactionId + '\n';
     output += '  ' + 'Account ID: ' + transactionAccountId + '\n';
@@ -214,8 +206,6 @@ async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, ta
     events.forEach(event => {
       const eventType = event.type;
       
-      console.log(eventType);
-
       if (eventType == 'TaskEnded') {
         taskEndedEventReceived = true;
       }

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ const session = require('express-session')
 const config = require('./config')
 
 const env = process.env.ENVIRONMENT
-console.log("Environment: " + env)
+console.log(`Environment: ${env}`)
 
 // Configure the OpenID Connect client based on the issuer.
 const issuer = new Issuer(config.issuer[`silverlake-${env}`]);
@@ -185,8 +185,10 @@ async function getAccountsAndTransactions(userId, res) {
     const accountId = account.id;
     const accountBalance = account.balance;
 
-    output += 'Account ID: ' + accountId + '\n';
-    output += '  ' + 'Balance: ' + accountBalance + '\n\n';
+    output += `
+    Account ID: ${accountId}
+      Balance: ${accountBalance }
+    `;
   });
 
   // GET Transactions
@@ -198,10 +200,12 @@ async function getAccountsAndTransactions(userId, res) {
     const transactionAmount = transaction.amount;
     const transactionMemo = transaction.memo;
 
-    output += 'Transaction ID: ' + transactionId + '\n';
-    output += '  ' + 'Account ID: ' + transactionAccountId + '\n';
-    output += '  ' + 'Amount: ' + transactionAmount + '\n';
-    output += '  ' + 'Memo: ' + transactionMemo + '\n\n';
+    output += `
+    Transaction ID: ${transactionId}
+      Account ID: ${transactionAccountId}
+      Amount: ${transactionAmount}
+      Memo: ${transactionMemo}
+    `;
   });
 
   res.set('Content-Type', 'text/plain').send(output);

--- a/server.js
+++ b/server.js
@@ -34,6 +34,11 @@ const client = new issuer.Client(config.client[`silverlake-${env}`]);
 
 client.CLOCK_TOLERANCE = 300; // to allow a 5 minute clock skew for verification
 
+//
+// TODO: Remove this testing variable!!!!
+//
+let apiCallCount = 0;
+
 // This example project doesn't include any storage mechanism(e.g. a database) for access tokens.
 // Therefore, we use this as our 'storage' for the purposes of this example.
 // This method is NOT recommended for use in production systems.
@@ -225,6 +230,12 @@ async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, ta
         taskEndedEventReceived = true;
       }
     });
+
+    if (!taskEndedEventReceived) {
+      // We should wait a while while the aggregation work is performed on the server,
+      // then we can check again.
+      sleep(3000);
+    }
   }
 }
 
@@ -266,4 +277,12 @@ async function putFetch(consumerApiPath, userId, accessToken) {
   const fetchApiJson = await fetchApiResponse.json();
   const taskId = fetchApiJson.taskId;
   return taskId;
+}
+
+function sleep(milliseconds) {
+  const date = Date.now();
+  let currentDate = null;
+  do {
+    currentDate = Date.now();
+  } while (currentDate - date < milliseconds);
 }

--- a/server.js
+++ b/server.js
@@ -155,7 +155,6 @@ app.get('/accountsAndTransactions', (req, res) => {
 
 async function getAccountsAndTransactions(userId, res) {
   // Set up
-  const bearerToken = accessToken;
   const consumerApiEnvironment = 'https://silverlake.banno-production.com'
   const consumerApiUsersBase = '/a/consumer/api/users/'
   const consumerApiPath = consumerApiEnvironment + consumerApiUsersBase;
@@ -163,15 +162,15 @@ async function getAccountsAndTransactions(userId, res) {
   let output = '';
 
   // PUT Fetch
-  const taskId = await putFetch(consumerApiPath, userId, bearerToken);
+  const taskId = await putFetch(consumerApiPath, userId, accessToken);
 
   console.log('Task ID: ' + taskId);
 
   // GET Tasks
-  await getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, taskId, bearerToken);
+  await getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, taskId, accessToken);
 
   // GET Accounts
-  const accounts = await getAccounts(consumerApiPath, userId, bearerToken);
+  const accounts = await getAccounts(consumerApiPath, userId, accessToken);
 
   accounts.forEach(account => {
     const accountId = account.id;
@@ -184,7 +183,7 @@ async function getAccountsAndTransactions(userId, res) {
   });
 
   // GET Transactions
-  const transactions = await getTransactions(consumerApiPath, userId, bearerToken);
+  const transactions = await getTransactions(consumerApiPath, userId, accessToken);
 
   transactions.forEach(transaction => {
     const transactionId = transaction.id;
@@ -203,12 +202,12 @@ async function getAccountsAndTransactions(userId, res) {
   res.set('Content-Type', 'text/plain').send(output);
 }
 
-async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, taskId, bearerToken) {
+async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, taskId, accessToken) {
   
   let taskEndedEventReceived = false;
   
   while (taskEndedEventReceived != true) {
-    const events = await getTasks(consumerApiPath, userId, taskId, bearerToken);
+    const events = await getTasks(consumerApiPath, userId, taskId, accessToken);
 
     events.forEach(event => {
       const eventType = event.type;
@@ -222,40 +221,40 @@ async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, ta
   }
 }
 
-async function getTransactions(consumerApiPath, userId, bearerToken) {
+async function getTransactions(consumerApiPath, userId, accessToken) {
   const transactionsApiResponse = await fetch(consumerApiPath + userId + '/transactions', {
     method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
+    headers: { 'Authorization': 'Bearer ' + accessToken }
   });
   const transactionsApiJson = await transactionsApiResponse.json();
   const transactions = transactionsApiJson.transactions;
   return transactions;
 }
 
-async function getAccounts(consumerApiPath, userId, bearerToken) {
+async function getAccounts(consumerApiPath, userId, accessToken) {
   const accountsApiResponse = await fetch(consumerApiPath + userId + '/accounts', {
     method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
+    headers: { 'Authorization': 'Bearer ' + accessToken }
   });
   const accountsApiJson = await accountsApiResponse.json();
   const accounts = accountsApiJson.accounts;
   return accounts;
 }
 
-async function getTasks(consumerApiPath, userId, taskId, bearerToken) {
+async function getTasks(consumerApiPath, userId, taskId, accessToken) {
   const tasksApiResponse = await fetch(consumerApiPath + userId + '/tasks/' + taskId, {
     method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
+    headers: { 'Authorization': 'Bearer ' + accessToken }
   });
   const tasksApiJson = await tasksApiResponse.json();
   const events = tasksApiJson.events;
   return events;
 }
 
-async function putFetch(consumerApiPath, userId, bearerToken) {
+async function putFetch(consumerApiPath, userId, accessToken) {
   const fetchApiResponse = await fetch(consumerApiPath + userId + '/fetch', {
     method: 'put',
-    headers: { 'Authorization': 'Bearer ' + bearerToken }
+    headers: { 'Authorization': 'Bearer ' + accessToken }
   });
   const fetchApiJson = await fetchApiResponse.json();
   const taskId = fetchApiJson.taskId;

--- a/server.js
+++ b/server.js
@@ -34,6 +34,11 @@ const client = new issuer.Client(config.client[`silverlake-${env}`]);
 
 client.CLOCK_TOLERANCE = 300; // to allow a 5 minute clock skew for verification
 
+// This example project doesn't include any storage mechanism(e.g. a database) for access tokens.
+// Therefore, we use this as our 'storage' for the purposes of this example.
+// This method is NOT recommended for use in production systems.
+let accessToken;
+
 // Configure the Passport strategy for OpenID Connect.
 const passportStrategy = new Strategy({
   client: client,
@@ -43,6 +48,7 @@ const passportStrategy = new Strategy({
   },
 }, (tokenSet, done) => {
   console.log(tokenSet)
+  accessToken = tokenSet.access_token;
   return done(null, tokenSet.claims);
 });
 
@@ -149,7 +155,7 @@ app.get('/accountsAndTransactions', (req, res) => {
 
 async function getAccountsAndTransactions(userId, res) {
   // Set up
-  const bearerToken = ''
+  const bearerToken = accessToken;
   const consumerApiEnvironment = 'https://silverlake.banno-production.com'
   const consumerApiUsersBase = '/a/consumer/api/users/'
   const consumerApiPath = consumerApiEnvironment + consumerApiUsersBase;

--- a/server.js
+++ b/server.js
@@ -143,19 +143,19 @@ app.get('/allthedata', (req, res) => {
 
   console.log('<=========================================================================================>');
 
-  getAccountsAndTransactions(req.session.passport.user.sub);
-  
-  res.set('Content-Type', 'text/plain').send(`allthedata ${req.session.passport.user.name}`);
+  getAccountsAndTransactions(req.session.passport.user.sub, res);
 });
 
 
-async function getAccountsAndTransactions(userId) {
+async function getAccountsAndTransactions(userId, res) {
   // Set up
   const bearerToken = ''
   const consumerApiEnvironment = 'https://silverlake.banno-production.com'
   const consumerApiUsersBase = '/a/consumer/api/users/'
   const consumerApiPath = consumerApiEnvironment + consumerApiUsersBase;
   
+  let output = '';
+
   // PUT Fetch
   const taskId = await putFetch(consumerApiPath, userId, bearerToken);
 
@@ -179,6 +179,9 @@ async function getAccountsAndTransactions(userId) {
     const accountBalance = account.balance;
 
     console.log('Account -> ID: ' + accountId + ' , Balance: ' + accountBalance);
+
+    output += 'Account ID: ' + accountId + '\n';
+    output += '  ' + 'Balance: ' + accountBalance + '\n\n';
   });
 
   // GET Transactions
@@ -186,11 +189,19 @@ async function getAccountsAndTransactions(userId) {
 
   transactions.forEach(transaction => {
     const transactionId = transaction.id;
+    const transactionAccountId = transaction.accountId;
     const transactionAmount = transaction.amount;
     const transactionMemo = transaction.memo;
 
     console.log('Transaction -> ID: ' + transactionId + ' , Amount: ' + transactionAmount + ' , Memo: ' + transactionMemo);
+
+    output += 'Transaction ID: ' + transactionId + '\n';
+    output += '  ' + 'Account ID: ' + transactionAccountId + '\n';
+    output += '  ' + 'Amount: ' + transactionAmount + '\n';
+    output += '  ' + 'Memo: ' + transactionMemo + '\n\n';
   });
+
+  res.set('Content-Type', 'text/plain').send(output);
 }
 
 async function getTransactions(consumerApiPath, userId, bearerToken) {

--- a/server.js
+++ b/server.js
@@ -143,13 +143,13 @@ app.get('/allthedata', (req, res) => {
 
   console.log('<=========================================================================================>');
 
-  doStuff3(req.session.passport.user.sub);
+  getAccountsAndTransactions(req.session.passport.user.sub);
   
   res.set('Content-Type', 'text/plain').send(`allthedata ${req.session.passport.user.name}`);
 });
 
 
-async function doStuff3(userId) {
+async function getAccountsAndTransactions(userId) {
   // Set up
   const bearer = ''
   const consumerApiEnvironment = 'https://silverlake.banno-production.com'

--- a/server.js
+++ b/server.js
@@ -152,6 +152,18 @@ app.get('/accountsAndTransactions', (req, res) => {
   getAccountsAndTransactions(userId, res);
 });
 
+app.use(express.static('public'));
+
+if (env === 'local') {
+  // Running the server locally requires a cert due to HTTPS requirement for the authentication callback.
+  const server = https.createServer({
+    key: fs.readFileSync('server.key'),
+    cert: fs.readFileSync('server.cert')
+  }, app)
+  server.listen(port, () => console.log(`Server listening on https://localhost:${port}...`))
+} else {
+  app.listen(port, () => console.log(`Server listening on http://localhost:${port}...`))
+}
 
 async function getAccountsAndTransactions(userId, res) {
   // Set up
@@ -251,17 +263,4 @@ async function putFetch(consumerApiPath, userId, accessToken) {
   const fetchApiJson = await fetchApiResponse.json();
   const taskId = fetchApiJson.taskId;
   return taskId;
-}
-
-app.use(express.static('public'));
-
-if (env === 'local') {
-  // Running the server locally requires a cert due to HTTPS requirement for the authentication callback.
-  const server = https.createServer({
-    key: fs.readFileSync('server.key'),
-    cert: fs.readFileSync('server.cert')
-  }, app)
-  server.listen(port, () => console.log(`Server listening on https://localhost:${port}...`))
-} else {
-  app.listen(port, () => console.log(`Server listening on http://localhost:${port}...`))
 }

--- a/server.js
+++ b/server.js
@@ -151,14 +151,14 @@ app.get('/allthedata', (req, res) => {
 
 async function getAccountsAndTransactions(userId) {
   // Set up
-  const bearer = ''
+  const bearerToken = ''
   const consumerApiEnvironment = 'https://silverlake.banno-production.com'
   const consumerApiUsersBase = '/a/consumer/api/users/'
   
   // PUT Fetch
   const fetchApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/fetch', {
     method: 'put',
-    headers: { 'Authorization': 'Bearer ' + bearer }
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
   });
   
   const fetchApiJson = await fetchApiResponse.json();
@@ -170,7 +170,7 @@ async function getAccountsAndTransactions(userId) {
   // GET Tasks
   const tasksApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/tasks/' + taskId, {
     method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearer }
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
   });
 
   const tasksApiJson = await tasksApiResponse.json();
@@ -186,7 +186,7 @@ async function getAccountsAndTransactions(userId) {
   // GET Accounts
   const accountsApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/accounts', {
     method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearer }
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
   });
 
   const accountsApiJson = await accountsApiResponse.json();
@@ -203,7 +203,7 @@ async function getAccountsAndTransactions(userId) {
   // GET Transactions
   const transactionsApiResponse = await fetch(consumerApiEnvironment + consumerApiUsersBase + userId + '/transactions', {
     method: 'get',
-    headers: { 'Authorization': 'Bearer ' + bearer }
+    headers: { 'Authorization': 'Bearer ' + bearerToken }
   });
 
   const transactionsApiJson = await transactionsApiResponse.json();

--- a/server.js
+++ b/server.js
@@ -135,9 +135,9 @@ app.get('/hello', (req, res) => {
   res.set('Content-Type', 'text/plain').send(`Hello ${req.session.passport.user.name}`);
 });
 
-app.get('/allthedata', (req, res) => {
+app.get('/accountsAndTransactions', (req, res) => {
   if (!req.isAuthenticated()) {
-    res.redirect('/login.html?returnPath=/allthedata');
+    res.redirect('/login.html?returnPath=/accountsAndTransactions');
     return;
   }
 

--- a/server.js
+++ b/server.js
@@ -168,7 +168,7 @@ if (env === 'local') {
 
 async function getAccountsAndTransactions(userId, res) {
   // Set up
-  const consumerApiPath = config.consumerApi.environment + config.consumerApi.usersBase;
+  const consumerApiPath = `${config.consumerApi.environment}${config.consumerApi.usersBase}`;
   
   let output = '';
 
@@ -229,7 +229,7 @@ async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, ta
 }
 
 async function getTransactions(consumerApiPath, userId, accessToken) {
-  const transactionsApiResponse = await fetch(consumerApiPath + userId + '/transactions', {
+  const transactionsApiResponse = await fetch(`${consumerApiPath}${userId}/transactions`, {
     method: 'get',
     headers: { 'Authorization': 'Bearer ' + accessToken }
   });
@@ -239,7 +239,7 @@ async function getTransactions(consumerApiPath, userId, accessToken) {
 }
 
 async function getAccounts(consumerApiPath, userId, accessToken) {
-  const accountsApiResponse = await fetch(consumerApiPath + userId + '/accounts', {
+  const accountsApiResponse = await fetch(`${consumerApiPath}${userId}/accounts`, {
     method: 'get',
     headers: { 'Authorization': 'Bearer ' + accessToken }
   });
@@ -249,7 +249,7 @@ async function getAccounts(consumerApiPath, userId, accessToken) {
 }
 
 async function getTasks(consumerApiPath, userId, taskId, accessToken) {
-  const tasksApiResponse = await fetch(consumerApiPath + userId + '/tasks/' + taskId, {
+  const tasksApiResponse = await fetch(`${consumerApiPath}${userId}/tasks/${taskId}`, {
     method: 'get',
     headers: { 'Authorization': 'Bearer ' + accessToken }
   });
@@ -259,7 +259,7 @@ async function getTasks(consumerApiPath, userId, taskId, accessToken) {
 }
 
 async function putFetch(consumerApiPath, userId, accessToken) {
-  const fetchApiResponse = await fetch(consumerApiPath + userId + '/fetch', {
+  const fetchApiResponse = await fetch(`${consumerApiPath}${userId}/fetch`, {
     method: 'put',
     headers: { 'Authorization': 'Bearer ' + accessToken }
   });

--- a/server.js
+++ b/server.js
@@ -168,9 +168,7 @@ if (env === 'local') {
 
 async function getAccountsAndTransactions(userId, res) {
   // Set up
-  const consumerApiEnvironment = 'https://silverlake.banno-production.com'
-  const consumerApiUsersBase = '/a/consumer/api/users/'
-  const consumerApiPath = consumerApiEnvironment + consumerApiUsersBase;
+  const consumerApiPath = config.consumerApi.environment + config.consumerApi.usersBase;
   
   let output = '';
 

--- a/server.js
+++ b/server.js
@@ -141,6 +141,7 @@ app.get('/hello', (req, res) => {
   res.set('Content-Type', 'text/plain').send(`Hello ${req.session.passport.user.name}`);
 });
 
+// This routing path shows the Accounts and Transactions for the authenticated user.
 app.get('/accountsAndTransactions', (req, res) => {
   if (!req.isAuthenticated()) {
     res.redirect('/login.html?returnPath=/accountsAndTransactions');

--- a/server.js
+++ b/server.js
@@ -34,11 +34,6 @@ const client = new issuer.Client(config.client[`silverlake-${env}`]);
 
 client.CLOCK_TOLERANCE = 300; // to allow a 5 minute clock skew for verification
 
-//
-// TODO: Remove this testing variable!!!!
-//
-let apiCallCount = 0;
-
 // This example project doesn't include any storage mechanism(e.g. a database) for access tokens.
 // Therefore, we use this as our 'storage' for the purposes of this example.
 // This method is NOT recommended for use in production systems.

--- a/server.js
+++ b/server.js
@@ -149,7 +149,9 @@ app.get('/accountsAndTransactions', (req, res) => {
 
   console.log('<=========================================================================================>');
 
-  getAccountsAndTransactions(req.session.passport.user.sub, res);
+  const userId = req.session.passport.user.sub;
+
+  getAccountsAndTransactions(userId, res);
 });
 
 


### PR DESCRIPTION
# Summary

This PR adds a new route `'/accountsAndTransactions'` which shows an example of how to retrieve `Accounts` and `Transactions` for a user.

The expectation is that developers can:
- Run the example project
- Navigate to https://localhost:8080/accountsAndTransactions
- Authenticate (if necessary)
- See the `Accounts` and `Transactions` pretty-printed to the returned page

# Example Output

```
Account ID: 024278d1-fbf0-1164-91e9-0eec49c9c5ef
  Balance: 25000.00

Account ID: 024278d0-fbf0-1191-e964-9c5ef0eec49c
  Balance: 50000.00

Transaction ID: de89ecf8fb574bbfda65b2043e8030c8a2241461
  Account ID: 024278d0-fbf0-1191-e964-9c5ef0eec49c
  Amount: 50000.00
  Memo: SAVINGS DEPOSIT

Transaction ID: d26a50a1e66080d2c394d197093b6a930702942a
  Account ID: 024278d1-fbf0-1164-91e9-0eec49c9c5ef
  Amount: 25000.00
  Memo: DEPOSIT
```

# Dependencies

This PR adds `node-fetch` as a dependency in `package.json`. It's used in this example project to make API requests easier to manage.

# Reviewer Notes

## Storage for Access Tokens

This example project doesn't include any storage mechanism (e.g. a database) for `Access Tokens`. Therefore, we use a global object as our 'storage' for the purposes of this example. This method is NOT recommended for use in production systems, and this caveat is noted as a comment in the code.

## Repetition of Authorization Header Setup

The instantiation of the `Authorization Header` is repeated in each of the helper functions that make API calls. Hypothetically this could be refactored into a separate method, but the choice here was to _emphasize_ the fact that a `Bearer Token` is required to use our API.

This design decision is born from the (far too many) times that I've sat and pondered why my new API call isn't working only to realize that I simply forgot to add the `Bearer Token`.

## Performance

This example project doesn't do anything too fancy with regard to handling use cases that involve very large numbers of accounts and/or transactions. This example is kept intentionally straightforward and easy to read since it is intended to educate and is not intended to be used in production systems.