### PR TITLE
feat: Switch to using account's transaction list

### DIFF
--- a/server.js
+++ b/server.js
@@ -169,7 +169,7 @@ if (env === 'local') {
 async function getAccountsAndTransactions(userId, res) {
   // Set up
   const consumerApiPath = `${config.consumerApi.environment}${config.consumerApi.usersBase}`;
-  
+
   let output = '';
 
   // PUT Fetch
@@ -184,21 +184,21 @@ async function getAccountsAndTransactions(userId, res) {
   for (const account of accounts) {
     const accountId = account.id;
     const accountBalance = account.balance;
-    
+
     output += `
     Account ID: ${accountId}
-      Balance: ${accountBalance }
+      Balance: ${accountBalance}
     `;
-    
+
     // GET Transactions
     const transactions = await getTransactions(consumerApiPath, userId, accountId, accessToken);
-    
+
     transactions.forEach(transaction => {
       const transactionId = transaction.id;
       const transactionAccountId = transaction.accountId;
       const transactionAmount = transaction.amount;
       const transactionMemo = transaction.memo;
-      
+
       output += `
       Transaction ID: ${transactionId}
         Account ID: ${transactionAccountId}
@@ -207,20 +207,20 @@ async function getAccountsAndTransactions(userId, res) {
       `;
     });
   }
-    
+
   res.set('Content-Type', 'text/plain').send(output);
 }
 
 async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, taskId, accessToken) {
-  
+
   let taskEndedEventReceived = false;
-  
+
   while (taskEndedEventReceived != true) {
     const events = await getTasks(consumerApiPath, userId, taskId, accessToken);
 
     events.forEach(event => {
       const eventType = event.type;
-      
+
       if (eventType == 'TaskEnded') {
         taskEndedEventReceived = true;
       }

--- a/server.js
+++ b/server.js
@@ -181,33 +181,33 @@ async function getAccountsAndTransactions(userId, res) {
   // GET Accounts
   const accounts = await getAccounts(consumerApiPath, userId, accessToken);
 
-  accounts.forEach(account => {
+  for (const account of accounts) {
     const accountId = account.id;
     const accountBalance = account.balance;
-
+    
     output += `
     Account ID: ${accountId}
       Balance: ${accountBalance }
     `;
-  });
-
-  // GET Transactions
-  const transactions = await getTransactions(consumerApiPath, userId, accessToken);
-
-  transactions.forEach(transaction => {
-    const transactionId = transaction.id;
-    const transactionAccountId = transaction.accountId;
-    const transactionAmount = transaction.amount;
-    const transactionMemo = transaction.memo;
-
-    output += `
-    Transaction ID: ${transactionId}
-      Account ID: ${transactionAccountId}
-      Amount: ${transactionAmount}
-      Memo: ${transactionMemo}
-    `;
-  });
-
+    
+    // GET Transactions
+    const transactions = await getTransactions(consumerApiPath, userId, accountId, accessToken);
+    
+    transactions.forEach(transaction => {
+      const transactionId = transaction.id;
+      const transactionAccountId = transaction.accountId;
+      const transactionAmount = transaction.amount;
+      const transactionMemo = transaction.memo;
+      
+      output += `
+      Transaction ID: ${transactionId}
+        Account ID: ${transactionAccountId}
+        Amount: ${transactionAmount}
+        Memo: ${transactionMemo}
+      `;
+    });
+  }
+    
   res.set('Content-Type', 'text/plain').send(output);
 }
 
@@ -234,8 +234,8 @@ async function getTasksUntilTaskEndedEventIsReceived(consumerApiPath, userId, ta
   }
 }
 
-async function getTransactions(consumerApiPath, userId, accessToken) {
-  const transactionsApiResponse = await fetch(`${consumerApiPath}${userId}/transactions`, {
+async function getTransactions(consumerApiPath, userId, accountId, accessToken) {
+  const transactionsApiResponse = await fetch(`${consumerApiPath}${userId}/accounts/${accountId}/transactions`, {
     method: 'get',
     headers: { 'Authorization': 'Bearer ' + accessToken }
   });


### PR DESCRIPTION
# Summary

Using the account's transaction list (`GET ​/users​/{userId}​/accounts​/{accountId}​/transactions`) instead of the user's transaction list (`GET ​/users​/{userId}​/transactions`) is more in line with how we want to have 3rd party developers use the API. There are performance benefits to using the account's transaction list rather than the user's transaction list.

In addition to using a different endpoint, this commit also reformats the output  of the `/accountsAndTransactions` route so it is visually clear that particular transactions belong to a particular account. The `async function getTransactions()` was modified to accept an `accountId` in order to retrieve the transactions for that `accountId`.

# Example Output
```
Account ID: 024278d1-fbf0-1164-91e9-0eec49c9c5ef
  Balance: 25000.00

  Transaction ID: 0a307029d26a542ae66080d2c394d1970913b6a9
    Account ID: 024278d1-fbf0-1164-91e9-0eec49c9c5ef
    Amount: 25000.00
    Memo: DEPOSIT
  
Account ID: 024278d0-fbf0-1191-e964-9c5ef0eec49c
  Balance: 50000.00

  Transaction ID: 74b4de89eca22bfda65b20414613e8030c8f8fb5
    Account ID: 024278d0-fbf0-1191-e964-9c5ef0eec49c
    Amount: 50000.00
    Memo: SAVINGS DEPOSIT
```