### PR TITLE
feat: add all OpenID Connect scopes

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,7 +44,7 @@ const passportStrategy = new Strategy({
   client: client,
   params: {
     redirect_uri: config.client[`silverlake-${env}`].redirect_uris[0],
-    scope: 'openid profile banno', // These are the OpenID Connect scopes that you'll need.
+    scope: 'openid address email phone profile banno', // These are the OpenID Connect scopes that you'll need.
   },
 }, (tokenSet, done) => {
   console.log(tokenSet)


### PR DESCRIPTION
# Summary

Adding these scopes to match the documentation and help illustrate the set of OpenID Connect scopes that can be requested during authentication.