### PR TITLE
fix!: switch to 2019silverlake environment

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,9 +2,9 @@ module.exports = {
   issuer: {
     'silverlake-local': {
       issuer: 'https://www.banno.com/a/consumer/api/oidc',
-      authorization_endpoint: 'https://silverlake.banno-production.com/a/consumer/api/oidc/auth',
-      token_endpoint: 'https://silverlake.banno-production.com/a/consumer/api/oidc/token',
-      jwks_uri: 'https://silverlake.banno-production.com/a/consumer/api/oidc/certs'
+      authorization_endpoint: 'https://2019silverlake.banno-production.com/a/consumer/api/oidc/auth',
+      token_endpoint: 'https://2019silverlake.banno-production.com/a/consumer/api/oidc/token',
+      jwks_uri: 'https://2019silverlake.banno-production.com/a/consumer/api/oidc/certs'
     }
   },
   client: {
@@ -18,7 +18,7 @@ module.exports = {
     }
   },
   consumerApi: {
-    environment: 'https://silverlake.banno-production.com',
+    environment: 'https://2019silverlake.banno-production.com',
     usersBase: '/a/consumer/api/v0/users/'
   }
 }

--- a/config.js
+++ b/config.js
@@ -9,8 +9,8 @@ module.exports = {
   },
   client: {
     'silverlake-local': {
-      client_id: '42b799f2-e543-4910-b5ec-e69fd458814b', // These credentials are designed for *demonstration* purposes only.
-      client_secret: 'd75b6fb3-91b8-4935-9251-651b294249de', // These credentials are designed for *demonstration* purposes only.
+      client_id: '55fc6a69-a4dd-404c-97f9-e2361b4c44b1', // These credentials are designed for *demonstration* purposes only.
+      client_secret: 'da9003cc-438a-4bbe-95d0-9af6ffe36d6a', // These credentials are designed for *demonstration* purposes only.
       grant_types: ['authorization_code'],
       response_types: ['code'],
       token_endpoint_auth_method: 'client_secret_basic',


### PR DESCRIPTION
# Summary

The old `silverlake` environment (https://silverlake.banno-production.com) has been decommissioned.

Its replacement is the `2019silverlake` environment (https://2019silverlake.banno-production.com).

This PR updates the example project to use the new environment.

# Work Performed

- Use new environment URLs.
- Generate new demo credentials.
  - Use update credentials in example project.

# Addresses Issue(s)

#12 