### PR TITLE
docs: remove implementation coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project is an example of how to connect to [Banno](https://banno.com/) serv
 
 This repository includes an example that uses [Node.js](https://nodejs.org) with the [Passport](http://www.passportjs.org/) authentication middleware to handle the OpenID Connect protocol.
 
+This example is best used when following along with the [Authentication Quickstart on JackHenry.Dev](https://jackhenry.dev/open-api-docs/consumer-api/quickstarts/Authentication/).
+
 # Prerequisites from Banno
 
 Before you get started with the example code, you'll need to get some credentials from [Banno](mailto:developerdocsite@banno.com).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository includes an example that uses [Node.js](https://nodejs.org) with
 
 # Prerequisites from Banno
 
-Before you get started with the example code, you'll need to get some credentials from your `Implementation Coordinator` at Banno.
+Before you get started with the example code, you'll need to get some credentials from [Banno](mailto:developerdocsite@banno.com).
 
 You'll need these credentials:
 - `client_id`


### PR DESCRIPTION
# Summary

Removing the `Implementation Coordinator` term as this ends up being misleading. This update changes the text to point folks towards contacting the Developer Docs Site mailing group (same as the "Contact Us" on the Banno Digital Toolkit main page).

This PR also adds a link to the Authentication Quickstart on JackHenry.Dev.