### PR TITLE
feat: make project usable as example of a Plugin

### DIFF
--- a/server.js
+++ b/server.js
@@ -64,7 +64,12 @@ app.use(session({
   // Note that this example project's particular cookie technique will only work in Chromium-based browsers e.g.
   // - Google Chrome
   // - newer versions of Microsoft Edge
-  // This cookie technique is NOT recommended for use in production systems.
+  //
+  // Note that these cookies are going to be blocked by Chromium-based browsers in the future, and are already
+  // blocked by Safari and Firefox by default.
+  //
+  // Safari can be made to work by disabling the "Prevent cross-site tracking" option. This will work for the developer,
+  // but isn't a solution for production usage.
   cookie: {
     sameSite: 'none',
     secure: true
@@ -105,13 +110,13 @@ app.get('/auth', (req, res, next) => {
 // This routing path handles the authentication callback.
 // This path (including the host information) must be configured in Banno SSO settings.
 app.get('/auth/cb', (req, res, next) => {
-  // This line is meant as a workaround for a specific issue that presents itself when attempting to use
-  // this example project to build a plugin for the Plugin Framework.
+  // This is an undocumented workaround for a quirk in how sessions are handled by this project's
+  // specific OpenID Connect client (https://github.com/panva/node-openid-client) dependency.
   //
-  // This works around a quirk in how sessions are handled by this project's
-  // OpenID Connect client (https://github.com/panva/node-openid-client) dependency.
+  // The issue presents itself when using this example project to build a plugin for the Plugin Framework.
   //
-  // This line is NOT recommended for use in production systems.
+  // Developers must ensure that protections are put in place to ensure that requests arriving
+  // without an existing session and state are not vulnerable to cross-site request forgeries.
   req.session[passportStrategy._key] = req.session[passportStrategy._key] || { 'key': 'DO_NOT_USE_IN_PRODUCTION'};
 
   passport.authenticate('openidconnect', (err, user, info) => {


### PR DESCRIPTION
# Summary

These changes make it possible to use this example project with the Plugin Framework, with some caveats:

This example project's particular cookie technique will only work in _Chromium-based_ browsers e.g.
- Google Chrome
- newer versions of Microsoft Edge

Safari has some caveats too.

The changes in this PR _also_ work around a quirk in how sessions are handled by this project's OpenID Connect client (https://github.com/panva/node-openid-client) dependency.