### PR TITLE
docs: direct readers to their admin for API creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This repository includes an example that uses [Node.js](https://nodejs.org) with
 
 This example is best used when following along with the [Authentication Quickstart on JackHenry.Dev](https://jackhenry.dev/open-api-docs/consumer-api/quickstarts/Authentication/).
 
-# Prerequisites from Banno
+# Prerequisites
 
-Before you get started with the example code, you'll need to get some credentials from [Banno](mailto:developerdocsite@banno.com).
+Before you get started, you'll need to get these from the back office administrator at your financial institution who has access to **Banno People**.
+
+_If the administrator does not know where to do this, they can review the [External application configuration](https://knowledge.banno.com/people/settings/external-application-configuration/) article on the Banno Knowledge site._
 
 You'll need these credentials:
 - `client_id`


### PR DESCRIPTION
# Summary

Previously, the "External applications" section of Banno People was not available to financial institutions (i.e. it was only available to Banno employees).

However, updates to the Banno People UI have made the "External applications" section available to FIs so they can now self-service their own API credentials.

# Jira Ticket

[DX-407 Update developer docs to point to Banno People admin](https://banno-jha.atlassian.net/browse/DX-407)