### PR TITLE
docs: add info about claims

### DIFF
--- a/server.js
+++ b/server.js
@@ -207,9 +207,9 @@ if (env === 'local') {
     key: fs.readFileSync('server.key'),
     cert: fs.readFileSync('server.cert')
   }, app)
-  server.listen(port, () => console.log(`Server listening on https://localhost:${port}...`))
+  server.listen(port, () => console.log(`Server listening on https://localhost:${port}`))
 } else {
-  app.listen(port, () => console.log(`Server listening on http://localhost:${port}...`))
+  app.listen(port, () => console.log(`Server listening on http://localhost:${port}`))
 }
 
 async function getAccountsAndTransactions(userId, res) {

--- a/server.js
+++ b/server.js
@@ -60,7 +60,7 @@ const passportStrategy = new Strategy({
     claims: JSON.stringify({
       // Authenticated information about the user can be returned in these ways:
       // - as Claims in the Identity Token,
-      // - as Claims returned from the UserInfo endpoint,
+      // - as Claims returned from the UserInfo Endpoint,
       // - as Claims in both the Identity Token and from the UserInfo Endpoint.
       //
       // See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const config = require('./config');
 
 const env = process.env.ENVIRONMENT;
 console.log(`Environment: ${env}`);
+console.log('API_ENVIRONMENT: ' + config.consumerApi.environment);
 
 (async () => {
 // Configure the OpenID Connect client based on the issuer.

--- a/server.js
+++ b/server.js
@@ -57,6 +57,12 @@ const passportStrategy = new Strategy({
     redirect_uri: config.client[`garden-${env}`].redirect_uris[0],
     scope: 'openid https://api.banno.com/consumer/auth/offline_access', // These are the OpenID Connect scopes that you'll need.
     claims: JSON.stringify({
+      // Authenticated information about the user can be returned in these ways:
+      // - as Claims in the Identity Token,
+      // - as Claims returned from the UserInfo endpoint,
+      // - as Claims in both the Identity Token and from the UserInfo Endpoint.
+      //
+      // See https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
       id_token: claims,
       userinfo: claims
     })


### PR DESCRIPTION
# Summary

This PR adds info about the various ways that `Claims` can be returned that describe authenticated information about the `User`.

The use case that this is trying to illustrate is how 3rd party developers can avoid receiving (and potentially _storing_) [PII](https://en.wikipedia.org/wiki/Personal_data) about the user in the form of `Claims` in the `Identity Token` yet still be able to retrieve such information on-demand when they need it (i.e. via the [UserInfo](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) Endpoint). 

This also adds a small feature to log the API Environment to the console. This can be useful debugging purposes. The output will look something like this when folks fire up the example project locally:

```
Environment: local
API_ENVIRONMENT: https://digital.garden-fi.com
Server listening on https://localhost:8080
```

# Jira Ticket

[DX-437 Update `Consumer API OIDC Example` to use V0 auth endpoints](https://banno-jha.atlassian.net/browse/DX-437)