### PR TITLE
feat: pretty-print Account type, subtype, routing number

### DIFF
--- a/server.js
+++ b/server.js
@@ -230,10 +230,16 @@ async function getAccountsAndTransactions(userId, res) {
   for (const account of accounts) {
     const accountId = account.id;
     const accountBalance = account.balance;
+    const accountType = account.accountType;
+    const accountSubtype = account.accountSubType;
+    const accountRoutingNumber = account.routingNumber;
 
     output += `
     Account ID: ${accountId}
       Balance: ${accountBalance}
+      Type: ${accountType}
+      Subtype: ${accountSubtype}
+      Routing Number: ${accountRoutingNumber}
     `;
 
     // GET Transactions


### PR DESCRIPTION
# Summary

This PR adds new pretty-printed values to the `/accountsAndTransactions` route (which is described in https://github.com/Banno/consumer-api-openid-connect-example#retrieving-accounts-and-transactions).

The result looks like this:

```yaml
    Account ID: 24467f59-fa18-4508-a954-fd024b818080
      Balance: 2.21
      Type: Deposit
      Subtype: Checking
      Routing Number: 998999861
    
      Transaction ID: 3a90da6543607c52332bd285ae27ee5546fd34b9
        Account ID: 24467f59-fa18-4508-a954-fd024b818080
        Amount: -1.01
        Memo: TEST BY CHAD
      
      Transaction ID: f10716ef9350ab42c8be9aad2cddc92d842dd1e4
        Account ID: 24467f59-fa18-4508-a954-fd024b818080
        Amount: 10000.00
        Memo: DEPOSIT
```

# Jira Ticket

[DX-485 Add Account Type, Subtype, and Routing Number to pretty-print](https://banno-jha.atlassian.net/browse/DX-485)