### PR TITLE
feat!: remove support for use w/ Plugin Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository includes an example that uses [Node.js](https://nodejs.org) with
 
 This example is best used when following along with the [Authentication Quickstart on JackHenry.Dev](https://jackhenry.dev/open-api-docs/consumer-api/quickstarts/Authentication/).
 
+## Note:
+
+If you're learning how to build a *plugin*, you should use this other example project - https://github.com/Banno/simple-plugin-example
+
 # Prerequisites
 
 Before you get started, you'll need to get these from the back office administrator at your financial institution who has access to **Banno People**.

--- a/server.js
+++ b/server.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// Note:
+// If you're learning how to build a *plugin*, you should use this other example project - 
+// https://github.com/Banno/simple-plugin-example
+
 'use strict';
 
 const fs = require('fs');

--- a/server.js
+++ b/server.js
@@ -91,20 +91,6 @@ app.use(session({
   secret: 'foo',
   resave: false,
   saveUninitialized: true,
-  // This example project can be used to build a plugin using the Plugin Framework.
-  // Note that this example project's particular cookie technique will only work in Chromium-based browsers e.g.
-  // - Google Chrome
-  // - newer versions of Microsoft Edge
-  //
-  // Note that these cookies are going to be blocked by Chromium-based browsers in the future, and are already
-  // blocked by Safari and Firefox by default.
-  //
-  // Safari can be made to work by disabling the "Prevent cross-site tracking" option. This will work for the developer,
-  // but isn't a solution for production usage.
-  cookie: {
-    sameSite: 'none',
-    secure: true
-  }
 }));
 
 app.use(passport.initialize());
@@ -141,15 +127,6 @@ app.get('/auth', (req, res, next) => {
 // This routing path handles the authentication callback.
 // This path (including the host information) must be configured in Banno SSO settings.
 app.get('/auth/cb', (req, res, next) => {
-  // This is an undocumented workaround for a quirk in how sessions are handled by this project's
-  // specific OpenID Connect client (https://github.com/panva/node-openid-client) dependency.
-  //
-  // The issue presents itself when using this example project to build a plugin for the Plugin Framework.
-  //
-  // Developers must ensure that protections are put in place to ensure that requests arriving
-  // without an existing session and state are not vulnerable to cross-site request forgeries.
-  req.session[passportStrategy._key] = req.session[passportStrategy._key] || { 'key': 'DO_NOT_USE_IN_PRODUCTION'};
-
   passport.authenticate('openidconnect', (err, user, info) => {
     console.log(err, user, info);
     if (err || !user) {


### PR DESCRIPTION
# Summary

This commit removes support for using the Consumer API OpenID Connect Example as a plugin.

The work done in https://github.com/Banno/consumer-api-openid-connect-example/pull/17 was useful, at the time, to show an example of building a plugin card with the Plugin Framework. However, we now have a *better* example in the form of the https://github.com/Banno/simple-plugin-example.

This commit undoes the changes in commit `dcb0509d304553d8098c9d036288792ea549bde3` (https://github.com/Banno/consumer-api-openid-connect-example/commit/dcb0509d304553d8098c9d036288792ea549bde3).

If someone is learning how to build a plugin, then they should use https://github.com/Banno/simple-plugin-example.

## Testing

Tested with all of these URLs:

- https://localhost:8080/login.html
- https://localhost:8080/me
- https://localhost:8080/hello
- https://localhost:8080/accountsAndTransactions

Each URL was tested in two scenarios:

1. signed out of Banno prior to running
2. signed in to Banno prior ro running    

# Jira Ticket(s)

[DX-478 Code: De-scope plugin responsibilities from Consumer API OIDC Example](https://banno-jha.atlassian.net/browse/DX-478)