### PR TITLE
Reduce friction points

### DIFF
--- a/server.js
+++ b/server.js
@@ -103,6 +103,8 @@ passport.use('openidconnect', passportStrategy);
 passport.serializeUser((user, done) => done(null, user));
 passport.deserializeUser((user, done) => done(null, user));
 
+// If you click on the URL in the log, "Server listening on http://localhost:8080", that will open the URL in your web browser.
+// In this case, we'll redirect you from the '/' route to the '/hello' route.
 app.get('/', (req, res, next) => {
   res.redirect('/hello');
 });
@@ -170,6 +172,7 @@ app.get('/me', (req, res) => {
   res.set('Content-Type', 'application/json').send(JSON.stringify(req.session.passport.user, undefined, 2));
 });
 
+// This routing path shows a text string with "Hello (user.name)".
 app.get('/hello', (req, res) => {
   if (!req.isAuthenticated()) {
     res.redirect('/login.html?returnPath=/hello');

--- a/server.js
+++ b/server.js
@@ -50,6 +50,10 @@ const claims = {
   address: null,
   phone: null,
   email: null,
+  // If you uncomment this line for the 'Unique Customer Identifer' Restricted claim,
+  // the administrator at the financial institution would also need to enable that restricted claim
+  // for the External Application used by this example in order to actually receive data for that claim.
+  //'https://api.banno.com/consumer/claim/customer_identifier': null,
   'https://api.banno.com/consumer/claim/institution_id': null
 };
 


### PR DESCRIPTION
# Summary

The purpose of this PR is to address some 'friction points' encountered by attendees at the [CU Build 2024](https://www.cubuild.org/) event.

It's similar in spirit to the work performed in https://github.com/Banno/simple-plugin-example/pull/22. However, there are some differences in the work performed due to differences in how the two example projects actually function.

## Work Performed

### docs: redirection of '/' to '/hello'

Folks sometimes click the log statement "Server listening on http://localhost:8080", which navigates them to the '/' route, which then gets redirected to the '/hello' route.

This was already handled, functionally, but didn't have comments explaining what was happening. So we add some in this commit.

### feat: Unique Customer Identifier (commented out)

This provides a line of code--commented out--and docs to explain how to retrieve the Unique Customer Identifier which is a Restricted Claim.

Since this is a Restricted Claim, we don't want folks to get confused by the fact that the claim isn't returned when the claim isn't turned on for the External Application.

The hope here is that the developer can reach out to the administrator at the Financial Institution to get the restricted claim turned on for their External Application. Then, they can uncomment this line and see the Unique Customer Identifier in the logs.

_Example log statement:_

(Assuming someone uncommented the necessary line)

```shell
TokenSet {
  [REDACTED FOR THIS PR EXAMPLE]
}
null {
  [REDACTED FOR THIS PR EXAMPLE]
  },
  email: '[REDACTED FOR THIS PR EXAMPLE]',
  'https://api.banno.com/consumer/claim/customer_identifier': 'LAA0007',
  'https://api.banno.com/consumer/claim/institution_id': '899f4398-106d-409a-9ed4-a72346778076',
  at_hash: 'OMTwj-y1JMEWbOSSq8NUdA',
  aud: '3f85ce95-00e7-4f3e-abbe-132d95f96d4e',
  exp: 1738373783,
  iat: 1738370183,
  iss: 'https://digital.garden-fi.com/a/consumer/api/v0/oidc'
} {}
```

Notice that the above has the `https://api.banno.com/consumer/claim/customer_identifier` Restricted Claim returned in the Identity Token. The overall Identity Token was already logged.

Also, the user's browser will show the Identity Token for the http://localhost:8080/me page.

(Example has redacted values)

```json
{
  ...
  "email": "[REDACTED FOR THIS PR EXAMPLE]",
  "https://api.banno.com/consumer/claim/customer_identifier": "LAA0007",
  "https://api.banno.com/consumer/claim/institution_id": "899f4398-106d-409a-9ed4-a72346778076",
  "at_hash": "OMTwj-y1JMEWbOSSq8NUdA",
  "aud": "3f85ce95-00e7-4f3e-abbe-132d95f96d4e",
  "exp": 1738373783,
  "iat": 1738370183,
  "iss": "https://digital.garden-fi.com/a/consumer/api/v0/oidc"
}
```

Notice that the above _also_ has the `https://api.banno.com/consumer/claim/customer_identifier` Restricted Claim.

## Notes

Some work that was _not_ performed:

1) Unlike https://github.com/Banno/simple-plugin-example/pull/22, we didn't need to 'log the Identity Token' here, because this example project was _already_ logging the Identity Token (in addition to displaying the Identity Token in the user's web browser).

2) Unlike https://github.com/Banno/simple-plugin-example/pull/22, this PR does not 'log the authorization URL'. I tried to implement this, but couldn't figure out how to do so even after reading the [Passport.js](https://www.passportjs.org/) docs. I also consulted online resources, but didn't find an answer.
- If we figure this out later, we can circle back to implement logging the authorization URL.

# Jira Ticket(s)

Finally resolves: [DX-1029 Code: Post-CU Build 2024 sample app updates](https://banno-jha.atlassian.net/browse/DX-1029)