### PR TITLE
fix: handle JWT signed with ES256 algorithm

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ module.exports = {
       grant_types: ['authorization_code'],
       response_types: ['code'],
       token_endpoint_auth_method: 'client_secret_post',
+      id_token_signed_response_alg: 'ES256',
       redirect_uris: ['http://localhost:8080/auth/cb']
     }
   },


### PR DESCRIPTION
# Summary'

Given OIDC Discovery configuration of https://digital.garden-fi.com/a/consumer/api/v0/oidc/.well-known/openid-configuration, we can find the JWKS https://digital.garden-fi.com/a/consumer/api/v0/oidc/jwks.

We would normally expect the `openid-client` to use the `kid` from a signed JWT to figure out which of the keys in the JWKS to use, and use the appropriate algorithm.

However, for some weird reason the local client configuration is defaulting to _always_ use `RS256` and therefore it fails with this error message if the signed JWT uses `ES256`:

```shell
RPError: unexpected JWT alg received, expected RS256, got: ES256

    at Client.validateJWT (/consumer-api-openid-connect-example/node_modules/openid-client/lib/client.js:890:13)

    at Client.validateIdToken (/consumer-api-openid-connect-example/node_modules/openid-client/lib/client.js:745:60)

    at Client.callback (/consumer-api-openid-connect-example/node_modules/openid-client/lib/client.js:488:18)

    at processTicksAndRejections (node:internal/process/task_queues:96:5)

    at async /consumer-api-openid-connect-example/node_modules/openid-client/lib/passport_strategy.js:155:22

```

Explicitly setting the `id_token_signed_response_alg` to `ES256` bypasses this weird quirk of the `openid-client`.

This step hypothetically shouldn't be necessary since the `openid-client` should just use the OIDC Discovery configuration to intelligently figure out the right thing to do.

Since it does not, in practice, we therefore need this workaround. Hopefully temporary.